### PR TITLE
Isolate blog map on OSM Leaflet (not Simple-CRS floorplan)

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -20,6 +20,7 @@
 	  <link rel="stylesheet" href="css/blog.css">
 
 	<script src="js/language.js"></script>
+  <!-- map.js still provides zoomto() for older stories. Blog map itself is initBlogMap() in js/blog.js (OSM), not pngMap(). -->
   <script src="js/map.js"></script>
         <script src="js/markdown.js"></script>
 		<script src="js/ui_engine.js"></script>

--- a/js/blog.js
+++ b/js/blog.js
@@ -26,11 +26,29 @@ var INDEX_MARKERS = [
     { label: '醉旅宿東京篇', type: 'collection', collection_id: '101', lat: 35.6812, lng: 139.7671 },
 ];
 
+// Public blog map: OSM geographic tiles (EPSG:3857), not map.js pngMap() Simple-CRS floorplan.
+function initBlogMap() {
+    var osm = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+        maxZoom: 19
+    });
+    mymap = L.map('map', {
+        crs: L.CRS.EPSG3857,
+        center: [25.1130643, 121.5227629],
+        zoom: 7,
+        minZoom: 2,
+        maxZoom: 19,
+        zoomControl: true,
+        scrollWheelZoom: true,
+        layers: [osm]
+    });
+}
+
 $(document).ready(function() {
     const i18n = new VueI18n({ locale: 'en', messages });
     new Vue({ i18n }).$mount('#dropdown');
 
-    initMap();
+    initBlogMap();
 
     ListmapData.load().done(function() {
         loadIndexMarkers();

--- a/scripts/test-static-data.js
+++ b/scripts/test-static-data.js
@@ -63,6 +63,18 @@ assert(m1024, 'blog.html missing story 1024 section');
 assert(!/javascript:zoomto/.test(m1024[0]), 'story 1024 must not use javascript:zoomto');
 assert((m1024[0].match(/class="map-place-link"/g) || []).length >= 5, 'story 1024 place links');
 assert(blogJs.includes('zoomToLandmarkId'), 'blog.js should zoom from static landmark JSON');
+assert(/function initBlogMap/.test(blogJs), 'blog.js should define initBlogMap');
+assert(blogJs.includes('initBlogMap()'), 'blog.js should call initBlogMap');
+assert(!/\binitMap\s*\(/.test(blogJs), 'blog.js must not call map.js initMap');
+assert(blogJs.includes('tile.openstreetmap.org'), 'blog map must use OSM tiles');
+assert(/scrollWheelZoom:\s*true/.test(blogJs), 'blog map must allow wheel zoom');
+assert(!/L\.CRS\.Simple/.test(blogJs), 'blog.js must not use Simple CRS');
+assert(!/mapbox/i.test(blogJs), 'blog.js must not use Mapbox tiles');
+
+const mapJs = fs.readFileSync(path.join(ROOT, 'js', 'map.js'), 'utf8');
+assert(/function pngMap/.test(mapJs), 'map.js pngMap should remain for non-blog pages');
+assert(/crs:\s*L\.CRS\.Simple/.test(mapJs), 'map.js pngMap should keep Simple CRS');
+assert(/function initMap/.test(mapJs), 'map.js initMap should remain for non-blog pages');
 
 const staticJsonPath = path.join(ROOT, 'data', 'static.json');
 assert(fs.existsSync(staticJsonPath), 'data/static.json missing — run npm run compile-data');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why
Public `blog.html` must be an OSM Leaflet map (pannable, zoomable, landmark pins), not `map.js` `pngMap()` Simple-CRS floorplan. Story 1024 / landmarks 475–479 stay on the existing static JSON (no `/api`).

## What changed
- `js/blog.js` initializes its own geographic OSM map via `initBlogMap()` (`EPSG:3857`, OSM tiles, `scrollWheelZoom: true`, `maxZoom: 19`).
- Blog no longer calls `map.js` `initMap()` (Mapbox) or `pngMap()` (Simple CRS).
- `map.js` `pngMap` / `initMap` are unchanged for any non-blog pages that still use them.
- `data/static.json` is untouched (S1024 + landmarks 475–479).

## Verification (must-pass, all green)

Served as `http://127.0.0.1:8765/Listmap_v0d3/` (project Pages base, no Node `/api`).

| Check | Result |
|---|---|
| Map CRS / tiles | `EPSG:3857`, `https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png`, attribution OpenStreetMap — **not** Simple CRS |
| Five S1024 pins | 九添福、璽子、成都老鍋、臻穎、文化城 |
| Click 璽子牛肉麵 | `flyTo` ~24.7991, 120.982 zoom 17 |
| Click 文化城牛肉麵 | `flyTo` ~24.8315, 121.0107 zoom 16–17 |
| Leaflet +/- and wheel zoom | enabled (`maxZoom` 19, `scrollWheelZoom` true); +/- confirmed in browser |
| `GET /Listmap_v0d3/data/static.json` | 200/304 |
| Runtime `/api` | **none** |
| `#1010` | Tokyo markers (羽田 / 成田 / 新宿); click 羽田 pans |

`npm test` passed (compile + wiring, including “blog does not call `initMap` / does not use Simple CRS”).

## Merge
Ready to merge after review. This repo has no GitHub Actions; local pass criteria are green. Does not change static JSON or break `map.js` floorplan helper.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e9d64074-9a9e-40f4-8e31-350f05c7735f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e9d64074-9a9e-40f4-8e31-350f05c7735f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

