### PR TITLE
Responsive map/copy split on blog and homepage

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -2,6 +2,7 @@
 <html>
    <head>
       <title>Listmap</title>
+      <meta name="viewport" content="width=device-width, initial-scale=1">
       <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css"
   integrity="sha512-xodZBNTC5n17Xt2atTPuE1HxjVMSvLVW9ocqUKLsCC5CXdbqCmblAshOMAS6/keqq/sMZMZ19scR4PsZChSR7A=="
   crossorigin=""/>
@@ -99,7 +100,7 @@
       </nav>
       <div class="containe-fluid" style="height:100%; width:100%;">
 
-         <div class="row" style="height:100%; width:100%;">
+         <div class="row map-split" style="height:100%; width:100%;">
             <div id="map" class="col left"></div>
             <div id="maplist">
 

--- a/css/blog.css
+++ b/css/blog.css
@@ -35,6 +35,56 @@
   width: 50%;
 }
 
+/* Split: wide = map left / copy right; narrow = map top / copy below. */
+body {
+  display: flex;
+  flex-direction: column;
+}
+body > .navbar {
+  flex-shrink: 0;
+}
+body > .containe-fluid {
+  flex: 1 1 auto;
+  min-height: 0;
+  height: auto !important;
+}
+.map-split {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  align-items: stretch;
+  min-height: 0;
+}
+@media (max-width: 767.98px) {
+  .map-split {
+    flex-direction: column;
+  }
+  .map-split > #map {
+    width: 100%;
+    max-width: 100%;
+    height: 42%;
+    flex: 0 0 42%;
+  }
+  .map-split > .right {
+    width: 100%;
+    max-width: 100%;
+    height: auto;
+    flex: 1 1 auto;
+    min-height: 0;
+  }
+  .map-split > #maplist,
+  .map-split > #maplist.maplist-visible {
+    position: relative;
+    top: auto;
+    left: auto;
+    width: 100%;
+    max-width: 100%;
+    height: auto;
+    max-height: 30%;
+    flex: 0 1 auto;
+  }
+}
+
 #maplist {
   background-color:white;
   position:absolute;

--- a/css/blog.css
+++ b/css/blog.css
@@ -54,6 +54,12 @@ body > .containe-fluid {
   flex-wrap: nowrap;
   align-items: stretch;
   min-height: 0;
+  margin-left: 0;
+  margin-right: 0;
+}
+.map-split > #map {
+  padding-left: 0;
+  padding-right: 0;
 }
 @media (max-width: 767.98px) {
   .map-split {

--- a/css/index.css
+++ b/css/index.css
@@ -35,6 +35,56 @@
   width: 50%;
 }
 
+/* Split: wide = map left / copy right; narrow = map top / copy below. */
+body {
+  display: flex;
+  flex-direction: column;
+}
+body > .navbar {
+  flex-shrink: 0;
+}
+body > .containe-fluid {
+  flex: 1 1 auto;
+  min-height: 0;
+  height: auto !important;
+}
+.map-split {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  align-items: stretch;
+  min-height: 0;
+}
+@media (max-width: 767.98px) {
+  .map-split {
+    flex-direction: column;
+  }
+  .map-split > #map {
+    width: 100%;
+    max-width: 100%;
+    height: 42%;
+    flex: 0 0 42%;
+  }
+  .map-split > .right {
+    width: 100%;
+    max-width: 100%;
+    height: auto;
+    flex: 1 1 auto;
+    min-height: 0;
+  }
+  .map-split > #maplist,
+  .map-split > #maplist.maplist-visible {
+    position: relative;
+    top: auto;
+    left: auto;
+    width: 100%;
+    max-width: 100%;
+    height: auto;
+    max-height: 30%;
+    flex: 0 1 auto;
+  }
+}
+
 #maplist {
   background-color:white;
   position:absolute;

--- a/css/index.css
+++ b/css/index.css
@@ -54,6 +54,12 @@ body > .containe-fluid {
   flex-wrap: nowrap;
   align-items: stretch;
   min-height: 0;
+  margin-left: 0;
+  margin-right: 0;
+}
+.map-split > #map {
+  padding-left: 0;
+  padding-right: 0;
 }
 @media (max-width: 767.98px) {
   .map-split {

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html>
    <head>
       <title>Listmap</title>
+      <meta name="viewport" content="width=device-width, initial-scale=1">
       <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css"
   integrity="sha512-xodZBNTC5n17Xt2atTPuE1HxjVMSvLVW9ocqUKLsCC5CXdbqCmblAshOMAS6/keqq/sMZMZ19scR4PsZChSR7A=="
   crossorigin=""/>
@@ -98,7 +99,7 @@
       </nav>
       <div class="containe-fluid" style="height:100%; width:100%;">
 
-         <div class="row" style="height:100%; width:100%;">
+         <div class="row map-split" style="height:100%; width:100%;">
             <div id="map" class="col left"></div>
             <div id="maplist">
 

--- a/js/map.js
+++ b/js/map.js
@@ -1,5 +1,28 @@
 const locations = []
 
+function invalidateMapSize() {
+    if (typeof mymap === 'undefined' || !mymap || typeof mymap.invalidateSize !== 'function') {
+        return;
+    }
+    mymap.invalidateSize({ animate: false });
+}
+
+function bindMapSizeInvalidation() {
+    if (bindMapSizeInvalidation._bound) {
+        invalidateMapSize();
+        return;
+    }
+    bindMapSizeInvalidation._bound = true;
+    var later = null;
+    function scheduleInvalidate() {
+        invalidateMapSize();
+        if (later) clearTimeout(later);
+        later = setTimeout(invalidateMapSize, 250);
+    }
+    window.addEventListener('resize', scheduleInvalidate);
+    window.addEventListener('orientationchange', scheduleInvalidate);
+}
+
 function flyto(lat, lng){
   mymap.flyTo(L.latLng(lat, lng), 18, {
       animate: true,
@@ -137,6 +160,8 @@ function initMap() {
         zoom: 7,
         layers: [streets]
     });
+
+    bindMapSizeInvalidation();
 
     mymap.on('zoomend', function() {
         console.log('zoom to:' + 'level(' + this.getZoom() + ') ' + this.getCenter());

--- a/scripts/test-static-data.js
+++ b/scripts/test-static-data.js
@@ -64,6 +64,27 @@ assert(!/javascript:zoomto/.test(m1024[0]), 'story 1024 must not use javascript:
 assert((m1024[0].match(/class="map-place-link"/g) || []).length >= 5, 'story 1024 place links');
 assert(blogJs.includes('zoomToLandmarkId'), 'blog.js should zoom from static landmark JSON');
 
+const mapJs = fs.readFileSync(path.join(ROOT, 'js', 'map.js'), 'utf8');
+assert(mapJs.includes('invalidateSize'), 'map.js should call invalidateSize on resize');
+assert(mapJs.includes('orientationchange'), 'map.js should invalidateSize on orientation change');
+assert((mapJs.match(/L\.map\(/g) || []).length >= 1, 'map.js should create a Leaflet map');
+
+const indexHtml = fs.readFileSync(path.join(ROOT, 'index.html'), 'utf8');
+assert(/name="viewport"/.test(blogHtml), 'blog.html needs viewport for mobile media queries');
+assert(/name="viewport"/.test(indexHtml), 'index.html needs viewport for mobile media queries');
+assert(/class="row map-split"/.test(blogHtml), 'blog.html should use one map-split row');
+assert(/class="row map-split"/.test(indexHtml), 'index.html should use one map-split row');
+assert(!fs.existsSync(path.join(ROOT, 'blog_m.html')), 'do not add a separate mobile blog HTML');
+assert(!fs.existsSync(path.join(ROOT, 'index_m.html')), 'do not add a separate mobile homepage HTML');
+
+const blogCss = fs.readFileSync(path.join(ROOT, 'css', 'blog.css'), 'utf8');
+const indexCss = fs.readFileSync(path.join(ROOT, 'css', 'index.css'), 'utf8');
+assert(/@media \(max-width:\s*767/.test(blogCss), 'blog.css needs a narrow-screen breakpoint');
+assert(/@media \(max-width:\s*767/.test(indexCss), 'index.css needs a narrow-screen breakpoint');
+assert(/flex-direction:\s*column/.test(blogCss), 'blog.css should stack map above copy on narrow screens');
+assert(/flex-direction:\s*column/.test(indexCss), 'index.css should stack map above copy on narrow screens');
+assert(!/javascript:zoomto/.test(indexJs), 'index.js must not use javascript:zoomto');
+
 const staticJsonPath = path.join(ROOT, 'data', 'static.json');
 assert(fs.existsSync(staticJsonPath), 'data/static.json missing — run npm run compile-data');
 const onDisk = JSON.parse(fs.readFileSync(staticJsonPath, 'utf8'));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Yu-Sheng approved a responsive layout on the **same** pages (no second HTML, no separate mobile site).

## Layout
- **≥768px:** map left, text/list right (existing desktop split).
- **&lt;768px:** map on top, text/list below. Homepage `#maplist` leaves the map overlay so pins stay visible.
- One Leaflet instance. Container flex only; `map.invalidateSize()` on `resize` and `orientationchange`.

## Scope
- `blog.html` (story + map) and homepage list + map.
- Static JSON loading unchanged (no `/api`). Project Pages base `/Listmap_v0d3/` still works.
- Story 1024 keeps `map-place-link` (no `javascript:zoomto`).

## Verify
Served at `/Listmap_v0d3/` (project Pages path):
- `/Listmap_v0d3/blog.html#1024` — desktop left/right; narrow map above copy; pins visible; Leaflet size matches container after rotate/resize.
- `/Listmap_v0d3/` — homepage list + map; on narrow the list sits below the map instead of covering it.

Wheel and pinch zoom stay enabled on the single map instance.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-37c922c4-00f1-43e2-b3d0-04809aac1ce4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37c922c4-00f1-43e2-b3d0-04809aac1ce4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

